### PR TITLE
fix: リリースフローが正しく動作していない

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,9 @@
+{
+  "git": {
+    "commitMessage": "chore(release): 🤖 v${version}",
+    "push": false
+  },
+  "github": {
+    "release": true
+  }
+}


### PR DESCRIPTION
release の GitHub Action を呼び出すと直で `main` push しようとしてエラーになる。
`main` push はせず、PRを作るように設定する

https://github.com/ubie-oss/design-tokens/actions/runs/20426161828/job/58686800297